### PR TITLE
fix: updated broken noise background GIF link

### DIFF
--- a/apps/ui-layout/content/components/noise.mdx
+++ b/apps/ui-layout/content/components/noise.mdx
@@ -9,7 +9,7 @@ export const metadata = {
 ```tsx
 <main className='relative '>
   <div
-    className="absolute top-0 left-0 w-full h-full content-[''] z-10 pointer-events-none bg-[url('https://res.cloudinary.com/dzl9yxixg/image/upload/noise_yvdidf.gif')]"
+    className="absolute top-0 left-0 w-full h-full content-[''] z-10 pointer-events-none bg-[url('https://res.cloudinary.com/diboqh2zz/image/upload/v1750142516/noise_ijem15.gif')]"
     style={{ opacity: opacity }}
   ></div>
   <section className='  font-semibold 2xl::h-[600px] sm:h-[500px] h-[450px] bg-gradient-to-t dark:to-gray-800 dark:from-gray-950 to-[#dadada] from-[#ebebeb] flex flex-col items-center justify-center dark:text-white text-black'>
@@ -32,7 +32,7 @@ play with opacity that helps you to reduce the noise:
 <main
   className="relative before:absolute before:top-0 before:left-0 before:w-full
      before:h-full before:content-[''] before:opacity-[0.05] before:z-10 before:pointer-events-none
-     before:bg-[url('https://res.cloudinary.com/dzl9yxixg/image/upload/noise_yvdidf.gif')]"
+     before:bg-[url('https://res.cloudinary.com/diboqh2zz/image/upload/v1750142516/noise_ijem15.gif')]"
 >
   {'your content here'}
 </main>


### PR DESCRIPTION
The original noise background GIF link was broken and the effect was not working properly.

I uploaded the same GIF to my own Cloudinary account and updated the URL reference to restore the intended background effect. 