### PR TITLE
fix: resolve media modal component name inconsistency

### DIFF
--- a/apps/ui-layout/configs/docs.ts
+++ b/apps/ui-layout/configs/docs.ts
@@ -2727,7 +2727,7 @@ export const AllComponents: IAllComponents[] = [
   },
   {
     category: DOCS_CATEGORY_KEY['media-modal'],
-    componentName: COMPONENT_KEYS.IMAGEMODALSL,
+    componentName: COMPONENT_KEYS.IMAGEMODALS,
     filesrc: 'components/modal/image-modals.tsx',
     tags: ['image modal', 'modal', 'popup', 'UI'],
     componentSrc: React.lazy(

--- a/apps/ui-layout/const/docs.ts
+++ b/apps/ui-layout/const/docs.ts
@@ -232,7 +232,7 @@ export const COMPONENT_KEYS = {
   DIALOG: 'dialog',
   RESPONSIVE_MODAL: 'responsive-modal',
   MEDIA_MODAL: 'media-modal',
-  IMAGEMODALSL: 'imagemodalsl',
+  IMAGEMODALS: 'imagemodals',
   LINEAR_MODAL: 'linear-modal',
   LINEAR_MODAL_STANDALONE: 'linear-modal-standalone',
   LINEAR_MODAL_CENTER_CONTENT: 'linear-modal-center-content',

--- a/apps/ui-layout/content/components/media-modal.mdx
+++ b/apps/ui-layout/content/components/media-modal.mdx
@@ -122,4 +122,4 @@ npm install motion
 
 Sometimes, we don't need reusable components because they are most useful when a component is used 2-3 times or more. However, in a single-page application, reusable components aren't always necessary. In such cases, you can use this component instead, and it will give you the same effect.
 
-<ComponentCodePreview name='imagemodalsl' hasReTrigger responsive />
+<ComponentCodePreview name='imagemodals' hasReTrigger responsive />


### PR DESCRIPTION
## Description

This PR focuses on **fixing component name inconsistency** in the media modal component.  
The changes address a typo in the component name that was causing rendering issues in the documentation.

### Changes
- **Component Name Fix**: Corrected IMAGEMODALSL to IMAGEMODALS in COMPONENT_KEYS for proper component identification.

## Motivation
- **Documentation Integrity**: Fix component rendering issues in media modal documentation.


### ASIS
<img width="1485" height="943" alt="스크린샷 2025-10-12 오후 8 37 30" src="https://github.com/user-attachments/assets/1fbcb3ea-f810-43e4-bc37-ed85e0f30c69" />

### TOBE
<img width="1503" height="932" alt="스크린샷 2025-10-12 오후 8 37 56" src="https://github.com/user-attachments/assets/ddae26cf-b25a-4ce8-8f8d-a225309bcae8" />
