### PR TITLE
fix: prevent drag icon scale from persisting during reordering

### DIFF
--- a/apps/ui-layout/registry/components/drag/drag-items.tsx
+++ b/apps/ui-layout/registry/components/drag/drag-items.tsx
@@ -66,6 +66,7 @@ const Item = ({ children, item }: { children: React.ReactNode; item: any }) => {
   const y = useMotionValue(0);
   const boxShadow = useRaisedShadow(y);
   const dragControls = useDragControls();
+  const [isDragging, setIsDragging] = useState(false);
 
   return (
     <Reorder.Item
@@ -73,22 +74,32 @@ const Item = ({ children, item }: { children: React.ReactNode; item: any }) => {
       style={{ boxShadow, y }}
       dragListener={false}
       dragControls={dragControls}
+      onDragStart={() => setIsDragging(true)}
+      onDragEnd={() => setIsDragging(false)}
       className='flex justify-between items-center w-full p-3 text-primary-foreground bg-primary border rounded-md'
     >
       <div>{children}</div>
-      <ReorderIcon dragControls={dragControls} />
+      <ReorderIcon
+        dragControls={dragControls}
+        isDragging={isDragging}
+        onPressStart={() => setIsDragging(true)}
+      />
     </Reorder.Item>
   );
 };
 interface Props {
   dragControls: DragControls;
+  isDragging: boolean;
+  onPressStart?: () => void;
 }
-export function ReorderIcon({ dragControls }: Props) {
+export function ReorderIcon({ dragControls, isDragging, onPressStart }: Props) {
   return (
     <motion.div
-      whileTap={{ scale: 0.85 }}
+      animate={{ scale: isDragging ? 0.85 : 1 }}
+      transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       onPointerDown={(e) => {
         e.preventDefault();
+        onPressStart?.();
         dragControls.start(e);
       }}
     >


### PR DESCRIPTION
closed #78 
## Description

This PR fixes a bug where the **drag icon remained scaled (`0.85`)** after dragging items **downward** within the `Reorder.Group`.  
The issue occurred because `whileTap` depends on the `pointerup` event being fired **on the same element**.  
When the drag started via `dragControls.start(e)`, the pointer was captured by the parent `Reorder.Item`,  
causing `whileTap` to **never receive the release event** — resulting in the icon staying enlarged indefinitely.

---

## Changes

- **Removed `whileTap`** from the drag icon (`ReorderIcon`) to prevent incorrect scale persistence  
- **Introduced `isDragging` state** inside `Item` to track drag lifecycle (`onDragStart`, `onDragEnd`)  
- Updated `ReorderIcon` to **animate scale** using the `isDragging` flag for reliable state sync  
- Added a **spring transition** for smoother recovery after drag release  

---

## Motivation

Previously, `whileTap` relied on receiving a `pointerup` event on the same element.  
However, when dragging started, the pointer was **captured by the parent** through `dragControls.start(e)`.  
This prevented the icon from receiving the release signal, causing the **scale to persist indefinitely**.  

By switching to a **drag lifecycle–based approach** (`onDragStart` / `onDragEnd`),  
the icon’s animation now resets **reliably regardless of drag direction or pointer capture**.

---

## Breaking Changes

None — this update only affects internal drag icon behavior and visual feedback.

---

https://github.com/user-attachments/assets/0b8dba18-359f-4d24-a5ce-e63d9fb560e1


