### PR TITLE
fix: move @property declaration to top-level for gradient-border comp…

### DIFF
--- a/apps/ui-layout/app/globals.css
+++ b/apps/ui-layout/app/globals.css
@@ -468,13 +468,6 @@
     width: 100%;
   }
 
-  @supports (property(--border-angle)) {
-    @property --border-angle {
-      inherits: false;
-      initial-value: 0deg;
-      syntax: '<angle>';
-    }
-  }
 
   /* Chrome, Safari, Edge, Opera */
   input::-webkit-outer-spin-button,
@@ -571,4 +564,10 @@
 .code-tabs {
   margin: 0 !important;
   padding: 0 !important;
+}
+
+@property --border-angle {
+  inherits: false;
+  initial-value: 0deg;
+  syntax: '<angle>';
 }


### PR DESCRIPTION
## Description

This PR fixes the **gradient-border animation bug** caused by invalid placement of the `@property` rule.  
Previously, the declaration was nested inside `@layer` and `@supports`, which prevented the browser from properly registering the `--border-angle` custom property.

### Changes
- Moved `@property` declaration to **top-level** for proper registration.
- Ensured `--border-angle` is globally available before keyframes and gradient logic.
- Verified that the `gradient-border` component now animates smoothly without missing variable errors.

### Motivation
Browsers ignore `@property` rules declared inside nested blocks like `@layer` or `@supports`.  
By moving it to the **top-level scope**, we ensure consistent animation and fix the missing `--border-angle` issue across all browsers.

### Screenshots
> ✅ Gradient border animation is now smooth and visible  

https://github.com/user-attachments/assets/b758b7e2-c633-458b-a600-30867982ba48




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified CSS property declaration structure for improved maintainability. No changes to user-facing appearance or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->